### PR TITLE
Changed getTickerApi to standardize the response

### DIFF
--- a/bitbnspy/bitbns.py
+++ b/bitbnspy/bitbns.py
@@ -99,12 +99,12 @@ class bitbns():
             req[key].pop('yes_price', None)
             req[key].pop('volume', None)
         if len(allSymbol) == 1 and allSymbol[0] == '':
-            return req
-        finallist = dict()
+            return {'data': req, 'status': 1, 'error': None}
+        finallist = {'data': dict(), 'status': 1, 'error': None}
         for item in allSymbol:
             if item not in req:
                 return self.genErrorMessage(None, 0, 'provide proper symbol')
-            finallist[item] = req[item]
+            finallist['data'][item] = req[item]
         return finallist
 
     def requestAuthenticate(self, symbol):


### PR DESCRIPTION
getTickerApi does not return 'data', 'error' or 'status' key when its returned successfully. It returns those keys when it results into an error. Have standardized that.